### PR TITLE
Integrate and fix unofficial gemini api

### DIFF
--- a/app/src/main/java/com/codex/apk/ChatMessageAdapter.java
+++ b/app/src/main/java/com/codex/apk/ChatMessageAdapter.java
@@ -362,6 +362,7 @@ public class ChatMessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
             if (layoutPlanSteps.getVisibility() == View.VISIBLE) {
                 recyclerPlanSteps.setAdapter(new PlanStepsAdapter(message.getPlanSteps()));
+                recyclerPlanSteps.setLayoutManager(new LinearLayoutManager(itemView.getContext()));
             }
 
             if (layoutWebSources.getVisibility() == View.VISIBLE) {


### PR DESCRIPTION
Improve Gemini integration for multi-turn conversations and enhance model-agnostic parsing and rendering of structured responses (plans, thoughts, web sources).

This PR addresses several issues with Gemini integration: it enables proper multi-turn conversations by persisting chat metadata per project; fixes the rendering of plans by ensuring the RecyclerView has a layout manager and consistently parsing plan JSON; separates and displays the 'thinking' part of the response; and gracefully handles web sources by parsing them from the normalized JSON output. These changes also make the response handling more model-agnostic, allowing the application to process structured data (like plans and file operations) from any provider that returns a normalized JSON format.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd3de534-f2f8-4c72-90f0-c620ee9b1f61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd3de534-f2f8-4c72-90f0-c620ee9b1f61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

